### PR TITLE
Fix Mamba feature dimension inference for HF graphs

### DIFF
--- a/icd/core/graph_pytorch.py
+++ b/icd/core/graph_pytorch.py
@@ -19,6 +19,14 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     TORCH_AVAILABLE = False
 
+if TORCH_AVAILABLE:
+    try:
+        import torch.nn as nn  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        nn = None  # type: ignore
+else:  # pragma: no cover - optional dependency
+    nn = None  # type: ignore
+
 from .graph import CSRMatrix
 
 
@@ -35,11 +43,15 @@ def _maybe_override_feature_dim_from_config(model: Any, current_dim: int) -> tup
         model_type = ""
 
     hidden_size = getattr(config, "hidden_size", None)
+    d_model = getattr(config, "d_model", None)
+    mtype = model_type.lower()
     if isinstance(hidden_size, int) and hidden_size > 0:
-        if model_type.lower() == "mamba" and hidden_size != current_dim:
+        if mtype in {"mamba", "mamba2", "ssm"} and hidden_size != current_dim:
             return hidden_size, "hf_config.hidden_size"
         if current_dim <= 0:
             return hidden_size, "hf_config.hidden_size"
+    if isinstance(d_model, int) and d_model > 0 and current_dim <= 0:
+        return d_model, "hf_config.d_model"
 
     return current_dim, None
 
@@ -47,35 +59,69 @@ def _maybe_override_feature_dim_from_config(model: Any, current_dim: int) -> tup
 def _infer_feature_dim_from_fx(gm: Any, fallback: int = 0) -> int:
     """Infer feature dimension from FX trace metadata.
 
-    Falls back to the provided ``fallback`` when inference fails. Chooses the
-    most common positive last-dimension size observed across FX nodes.
+    Falls back to the provided ``fallback`` when inference fails. Prioritises
+    nn.Linear ``out_features`` metadata, then matmul-style ops, and finally
+    generic last-dimension shape votes to avoid being dominated by Conv1d
+    traces that expose the sequence length as the final dimension.
     """
 
     if gm is None:
         return fallback
 
-    dims: List[int] = []
+    dims_last: List[int] = []
+    dims_linear: List[int] = []
+    dims_matmul: List[int] = []
     graph = getattr(gm, "graph", None)
     nodes = getattr(graph, "nodes", []) if graph is not None else []
+    get_submodule = getattr(gm, "get_submodule", None)
     for node in nodes:
         meta = getattr(node, "meta", {})
         tensor_meta = meta.get("tensor_meta") if isinstance(meta, dict) else getattr(meta, "tensor_meta", None)
         shape = getattr(tensor_meta, "shape", None)
-        if shape is None or not hasattr(shape, "__len__") or len(shape) < 2:
-            continue
-        try:
-            last = int(shape[-1])
-        except Exception:
-            continue
-        if last > 0:
-            dims.append(last)
+        # 1) Prefer explicit nn.Linear out_features metadata when available
+        if (
+            getattr(node, "op", "") == "call_module"
+            and callable(get_submodule)
+            and nn is not None
+        ):
+            try:
+                sub = get_submodule(node.target)
+                if isinstance(sub, nn.Linear) and getattr(sub, "out_features", 0) > 0:
+                    dims_linear.append(int(sub.out_features))
+                    continue
+            except Exception:
+                pass
 
-    if not dims:
-        return fallback
+        # 2) Trust matrix multiplications that preserve feature dimension ordering
+        if getattr(node, "op", "") == "call_function":
+            fn = node.target
+            fn_name = getattr(fn, "__name__", str(fn))
+            if fn_name in {"addmm", "mm", "matmul", "bmm"}:
+                if shape is not None and hasattr(shape, "__len__") and len(shape) >= 2:
+                    try:
+                        last = int(shape[-1])
+                        if last > 0:
+                            dims_matmul.append(last)
+                        continue
+                    except Exception:
+                        pass
 
-    counts = Counter(dims)
-    inferred, _ = max(counts.items(), key=lambda kv: (kv[1], kv[0]))
-    return inferred if inferred > 0 else fallback
+        # 3) Fall back to last-dimension shape votes (may be polluted by Conv1d)
+        if shape is not None and hasattr(shape, "__len__") and len(shape) >= 2:
+            try:
+                last = int(shape[-1])
+                if last > 0:
+                    dims_last.append(last)
+            except Exception:
+                pass
+
+    for votes in (dims_linear, dims_matmul, dims_last):
+        if votes:
+            counts = Counter(votes)
+            inferred, _ = max(counts.items(), key=lambda kv: (kv[1], -kv[0]))
+            if inferred > 0:
+                return inferred
+    return fallback
 
 
 def _fallback_w(
@@ -299,6 +345,16 @@ def build_w_from_pytorch(
     import hashlib, json as _json
     trace_hash = hashlib.sha256(_json.dumps([(m["name"], m["shape"]) for m in used_meta]).encode("utf-8")).hexdigest()
 
+    inter_size = None
+    try:
+        config = getattr(model, "config", None)
+        if config is not None:
+            maybe_inter = getattr(config, "intermediate_size", None)
+            if isinstance(maybe_inter, int) and maybe_inter > 0:
+                inter_size = maybe_inter
+    except Exception:
+        inter_size = None
+
     meta = {
         "shape": D,
         "format": "csr",
@@ -316,6 +372,11 @@ def build_w_from_pytorch(
             "feature_dim_source": feature_dim_source,
         },
     }
+    if inter_size and D > 0:
+        intermediate_meta: Dict[str, Any] = {"size": inter_size}
+        if inter_size % D == 0:
+            intermediate_meta["expansion_factor"] = inter_size // D
+        meta["pytorch"]["intermediate"] = intermediate_meta
     if att_meta is not None:
         meta["pytorch"]["attention"] = att_meta
     return CSRMatrix(indptr=indptr, indices=indices, data=data, shape=(D, D), meta=meta)

--- a/icd/core/graph_pytorch.py
+++ b/icd/core/graph_pytorch.py
@@ -71,7 +71,10 @@ def _infer_feature_dim_from_fx(gm: Any, fallback: int = 0) -> int:
     dims_last: List[int] = []
     dims_linear: List[int] = []
     dims_matmul: List[int] = []
+
     def _accept_dim(val: int) -> bool:
+        # Clamp to a plausible hidden-width window so LM heads (|V|) or long
+        # sequence axes do not dominate the vote tally.
         return 16 <= val <= 32768
     graph = getattr(gm, "graph", None)
     nodes = getattr(graph, "nodes", []) if graph is not None else []

--- a/tests/test_feature_dim_infer.py
+++ b/tests/test_feature_dim_infer.py
@@ -7,6 +7,7 @@ from torch import fx
 from icd.core.graph_pytorch import (
     _infer_feature_dim_from_fx,
     _maybe_override_feature_dim_from_config,
+    build_w_from_pytorch,
 )
 
 
@@ -30,6 +31,24 @@ class ToyModel(nn.Module):
         z = self.conv(z)
         z = z.transpose(1, 2)
         return y + z
+
+
+class TinyLM(nn.Module):
+    def __init__(self, d: int = 96, vocab: int = 50000, heads: int = 12):
+        super().__init__()
+        self.l1 = nn.Linear(d, 4 * d)
+        self.l2 = nn.Linear(4 * d, d)
+        self.lm_head = nn.Linear(d, vocab)
+        self.config = types.SimpleNamespace(
+            model_type="mamba2",
+            hidden_size=d,
+            intermediate_size=4 * d,
+            num_attention_heads=heads,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.l2(torch.relu(self.l1(x)))
+        return self.lm_head(h)
 
 
 def _shape_prop(gm: fx.GraphModule, *example_inputs: torch.Tensor) -> None:
@@ -67,3 +86,23 @@ def test_config_override_uses_d_model_when_hidden_missing():
     override, source = _maybe_override_feature_dim_from_config(model, current)
     assert override == d_model
     assert source == "hf_config.d_model"
+
+
+@torch.no_grad()
+def test_build_w_uses_config_for_attention_meta() -> None:
+    model = TinyLM(d=96, vocab=50000, heads=12).eval()
+    example = torch.randn(1, 32, 96)
+    W = build_w_from_pytorch(model, example, seed=0)
+
+    meta = W.meta["pytorch"]
+    assert meta["feature_dim"] == 96
+    assert meta["feature_dim_source"] in {"hf_config.hidden_size", "fx", "tensor"}
+
+    inter = meta.get("intermediate", {})
+    assert inter["size"] == 384
+    assert inter["expansion_factor"] == 4
+
+    att = meta.get("attention", {})
+    assert att["enabled"] is True
+    assert att["head_dim"] == 8
+    assert att["num_heads"] == 12

--- a/tests/test_feature_dim_infer.py
+++ b/tests/test_feature_dim_infer.py
@@ -1,0 +1,69 @@
+import types
+
+import torch
+import torch.nn as nn
+from torch import fx
+
+from icd.core.graph_pytorch import (
+    _infer_feature_dim_from_fx,
+    _maybe_override_feature_dim_from_config,
+)
+
+
+class ToyModel(nn.Module):
+    def __init__(self, hidden: int = 64, intermediate: int = 128):
+        super().__init__()
+        self.l1 = nn.Linear(hidden, intermediate)
+        self.l2 = nn.Linear(intermediate, hidden)
+        self.conv = nn.Conv1d(hidden, hidden, kernel_size=3, padding=1)
+        self.config = types.SimpleNamespace(
+            model_type="mamba2",
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = self.l1(x)
+        y = torch.relu(y)
+        y = self.l2(y)
+        z = x.transpose(1, 2)
+        z = self.conv(z)
+        z = z.transpose(1, 2)
+        return y + z
+
+
+def _shape_prop(gm: fx.GraphModule, *example_inputs: torch.Tensor) -> None:
+    from torch.fx.passes.shape_prop import ShapeProp
+
+    ShapeProp(gm).propagate(*example_inputs)
+
+
+@torch.no_grad()
+def test_fx_prefers_linear_over_conv_lastdim():
+    hidden = 64
+    model = ToyModel(hidden=hidden, intermediate=hidden * 2).eval()
+    example = torch.randn(2, 4096, hidden)
+    gm = fx.symbolic_trace(model)
+    _shape_prop(gm, example)
+    inferred = _infer_feature_dim_from_fx(gm, fallback=0)
+    assert inferred == hidden
+
+
+def test_config_override_prefers_hidden_size_for_mamba_family():
+    current = 4096
+    hidden = 96
+    model = ToyModel(hidden=hidden, intermediate=hidden * 2)
+    model.config = types.SimpleNamespace(model_type="mamba2", hidden_size=hidden)
+    override, source = _maybe_override_feature_dim_from_config(model, current)
+    assert override == hidden
+    assert source == "hf_config.hidden_size"
+
+
+def test_config_override_uses_d_model_when_hidden_missing():
+    current = 0
+    d_model = 128
+    model = ToyModel(hidden=d_model, intermediate=d_model * 2)
+    model.config = types.SimpleNamespace(model_type="ssm", d_model=d_model)
+    override, source = _maybe_override_feature_dim_from_config(model, current)
+    assert override == d_model
+    assert source == "hf_config.d_model"

--- a/tests/test_feature_dim_robust.py
+++ b/tests/test_feature_dim_robust.py
@@ -1,0 +1,55 @@
+import types
+
+import torch
+import torch.nn as nn
+from torch import fx
+
+from icd.core.graph_pytorch import (
+    _infer_feature_dim_from_fx,
+    _infer_feature_dim_from_tensor,
+)
+
+
+class TinyLM(nn.Module):
+    def __init__(self, d: int = 64, vocab: int = 50000):
+        super().__init__()
+        self.l1 = nn.Linear(d, 4 * d)
+        self.l2 = nn.Linear(4 * d, d)
+        self.lm_head = nn.Linear(d, vocab)
+        self.config = types.SimpleNamespace(
+            model_type="mamba2", hidden_size=d, intermediate_size=4 * d
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.l2(torch.relu(self.l1(x)))
+        logits = self.lm_head(h)
+        return logits
+
+
+def _shape_prop(gm: fx.GraphModule, *inputs: torch.Tensor) -> None:
+    from torch.fx.passes.shape_prop import ShapeProp
+
+    ShapeProp(gm).propagate(*inputs)
+
+
+def test_fx_ignores_vocab_pollution() -> None:
+    m = TinyLM(d=96, vocab=50000).eval()
+    gm = fx.symbolic_trace(m)
+    ex = torch.randn(2, 4096, 96)
+    _shape_prop(gm, ex)
+    D = _infer_feature_dim_from_fx(gm, fallback=ex.shape[-1])
+    assert D == 96
+
+
+def test_tensor_fallback_2d_required() -> None:
+    x = torch.randn(8)
+    assert _infer_feature_dim_from_tensor(x) == 0
+
+
+def test_fx_prefers_fallback_on_tie() -> None:
+    m = TinyLM(d=128, vocab=4096).eval()
+    gm = fx.symbolic_trace(m)
+    ex = torch.randn(1, 4096, 128)
+    _shape_prop(gm, ex)
+    D = _infer_feature_dim_from_fx(gm, fallback=128)
+    assert D == 128


### PR DESCRIPTION
## Summary
- derive the feature dimension for HuggingFace models using FX metadata with a fallback to configuration hidden_size
- record the inferred feature dimension and its source in the PyTorch graph metadata to aid downstream tooling

## Testing
- pytest icd/runtime/tests/test_pi.py::test_apply_pi_sequence_skips_mamba_mismatch

------
https://chatgpt.com/codex/tasks/task_e_68dbba6bc0788333a4e6964ec9d8ca2a